### PR TITLE
Revamp error handling

### DIFF
--- a/sources/helpers/apollo.js
+++ b/sources/helpers/apollo.js
@@ -1,3 +1,5 @@
+const { ApolloError} = require('apollo-server');
+
 const responseResolver=(name)=>{
     return {
 		__resolveType: (obj) => {
@@ -6,6 +8,17 @@ const responseResolver=(name)=>{
 	}
 }
 
+const resolverHelper=(graphqlError,requiredPermission,permissions)=>{
+	if(graphqlError){
+		throw new ApolloError(graphqlError.message,graphqlError.code);
+	}else if (permissions.find((permission) => permission == requiredPermission)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
 module.exports={
-    responseResolver
+	responseResolver,
+	resolverHelper
 }

--- a/sources/resolvers/accessLevel.js
+++ b/sources/resolvers/accessLevel.js
@@ -2,29 +2,23 @@
 
 const queries = {};
 const ERRORS = require('../errors');
-const {responseResolver}=require('../helpers/apollo');
+const {responseResolver,resolverHelper}=require('../helpers/apollo');
 
 const mutations = {
-	addAccessLevel: (parent, { accessLevel }, { dataSources, permissions }, info) => {
-		if (permissions.find((permission) => permission == 'accessLevels.CRUD')) {
-			return dataSources.AccessLevelAPI.addAccessLevel(accessLevel);
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}		
+	addAccessLevel: (parent, { accessLevel }, { dataSources, permissions, error }, info) => {
+		return resolverHelper(error,'accessLevels.CRUD',permissions) 
+			?  dataSources.AccessLevelAPI.addAccessLevel(accessLevel)
+			: ERRORS.PERMISSION_DENIED					
 	},
-	updateAccessLevel: (parent, args, { dataSources, permissions }, info) => {
-		if (permissions.find((permission) => permission == 'accessLevels.CRUD')) {
-			return dataSources.AccessLevelAPI.updateAccessLevel(args);
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}				
+	updateAccessLevel: (parent, args, { dataSources, permissions, error }, info) => {
+		return resolverHelper(error,'accessLevels.CRUD',permissions) 
+			?  dataSources.AccessLevelAPI.updateAccessLevel(args)
+			: ERRORS.PERMISSION_DENIED		
 	},
-	deleteAccessLevel: (parent, { id }, { dataSources, permissions }, info) => {
-		if (permissions.find((permission) => permission == 'accessLevels.CRUD')) {
-			return dataSources.AccessLevelAPI.deleteAccessLevel(id);
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}		
+	deleteAccessLevel: (parent, { id }, { dataSources, permissions, error }, info) => {
+		return resolverHelper(error,'accessLevels.CRUD',permissions) 
+			?  dataSources.AccessLevelAPI.deleteAccessLevel(id)
+			: ERRORS.PERMISSION_DENIED						
 	},
 };
 

--- a/sources/resolvers/club.js
+++ b/sources/resolvers/club.js
@@ -1,5 +1,6 @@
 /** @format */
 const ERRORS = require('../errors');
+const {resolverHelper} = require("../helpers/apollo");
 
 const queries = {
 	clubs: (parent, args, { dataSources }, info) => {
@@ -11,29 +12,23 @@ const queries = {
 	clubById: (parent, { id }, { dataSources }, info) => {
 		return dataSources.ClubAPI.getClubById(id);
 	},
-	deleteClub: (parent, { id }, { dataSources, permissions }, info) => {
-		if (permissions.find((permission) => permission == 'clubs.delete$'+id)) {
-			return dataSources.ClubAPI.deleteClub(id);
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}						
+	deleteClub: (parent, { id }, { dataSources, permissions, error }, info) => {
+		return resolverHelper(error,'clubs.delete$'+id,permissions) 
+			?  dataSources.ClubAPI.deleteClub(id)
+			: ERRORS.PERMISSION_DENIED								
 	},
 };
 
 const mutations = {
-	addClub: (parent, { club }, { dataSources,permissions }, info) => {		
-		if (permissions.find((permission) => permission == 'clubs.add')) {
-			return dataSources.ClubAPI.addClub(club);
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}		
+	addClub: (parent, { club }, { dataSources,permissions, error }, info) => {		
+		return resolverHelper(error,'clubs.add',permissions) 
+			?  dataSources.ClubAPI.addClub(club)
+			: ERRORS.PERMISSION_DENIED		
 	},
-	updateClub: (parent, args, { dataSources, permissions }, info) => {
-		if (permissions.find((permission) => permission == 'clubs.update$'+args.id)) {
-			return dataSources.ClubAPI.updateClub(args);
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}				
+	updateClub: (parent, args, { dataSources, permissions, error }, info) => {
+		return resolverHelper(error,'clubs.update$'+args.id,permissions) 
+			?  dataSources.ClubAPI.updateClub(args)
+			: ERRORS.PERMISSION_DENIED		
 	}
 };
 

--- a/sources/resolvers/story.js
+++ b/sources/resolvers/story.js
@@ -2,34 +2,29 @@
 
 const ERRORS = require('../errors');
 const permissions= require("../models/permission");
+const {resolverHelper} = require("../helpers/apollo");
 
 const queries = {
 	storiesByField: (parent, args, { dataSources }, info) => {
 		return dataSources.StoryAPI.getStories(args);
     },
-    currentStories: (parent, args, { dataSources, permissions }, info) => {
-		if (permissions.find((permission) => permission == 'stories.view')) {				
-			return dataSources.StoryAPI.getCurrentStories();
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}			
+    currentStories: (parent, args, { dataSources, permissions, error }, info) => {
+		return resolverHelper(error,'stories.view',permissions) 
+			?  dataSources.StoryAPI.getCurrentStories()
+			: ERRORS.PERMISSION_DENIED							
 	},
-	deleteStory: async (parent, args , { dataSources ,uid,permissions}, info) => {
-		if (permissions.find((permission) => permission == 'stories.delete$'+args.author)) {			
-			return dataSources.StoryAPI.deleteStory(args); 
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}		
+	deleteStory: async (parent, args , { dataSources ,uid,permissions,error}, info) => {
+		return resolverHelper(error, 'stories.delete$'+args.author,permissions) 
+			?  dataSources.StoryAPI.deleteStory(args)
+			: ERRORS.PERMISSION_DENIED											
 	}
 };
 
 const mutations = {
-	addStory: async (parent, { story }, { dataSources ,uid,permissions}, info) => {
-		if (permissions.find((permission) => permission == 'stories.add$'+story.author)) {			
-			return dataSources.StoryAPI.addStory(story);
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}		
+	addStory: async (parent, { story }, { dataSources ,uid,permissions,error}, info) => {
+		return resolverHelper(error, 'stories.add$'+story.author,permissions) 
+			?  dataSources.StoryAPI.addStory(story)
+			: ERRORS.PERMISSION_DENIED						
 	}
 };
 

--- a/sources/resolvers/user.js
+++ b/sources/resolvers/user.js
@@ -1,50 +1,42 @@
 /** @format */
 
+const { Error } = require('mongoose');
 const ERRORS = require('../errors');
+const {resolverHelper} = require("../helpers/apollo");
 
 const queries = {
-	users: (parent, args, { dataSources,permissions }, info) => {
-		if (permissions.find((permission) => permission == 'users.all')) {
-			return dataSources.UserAPI.getUsers(args);
-		} else {
-			return [ERRORS.PERMISSION_DENIED];
-		}
+	users: (parent, args, { dataSources,permissions,error }, info) => {
+		return resolverHelper(error,'users.all',permissions) 
+			?  dataSources.UserAPI.getUsers(args)
+			: [ERRORS.PERMISSION_DENIED]		
 	},
 	/**
 	 * Resolver for User by Username.
 	 * @param {string} username - username query
 	 * @reutrns {Object} User - User with the queries username
 	 */
-	userByUsername: async (parent, { username }, { dataSources,uid, permissions }, info) => {
-		if (permissions.find((permission) => permission == 'users.byName')) {
-			return dataSources.UserAPI.getUserByUsername(username);
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}
+	userByUsername: async (parent, { username }, { dataSources,uid, permissions,error }, info) => {
+		return resolverHelper(error,'users.byName',permissions) 
+			?  dataSources.UserAPI.getUserByUsername(username)
+			: ERRORS.PERMISSION_DENIED				
 	},
-	userById: async (parent, { id }, {dataSources,uid, permissions }, info) => {
-		if (permissions.find((permission) => permission == 'users.byId')) {
-			return dataSources.UserAPI.getUserById(id);
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}
+	userById: async (parent, { id }, {dataSources,uid, permissions, error }, info) => {
+		return resolverHelper(error,'users.byId',permissions) 
+			?  dataSources.UserAPI.getUserById(id)
+			: ERRORS.PERMISSION_DENIED				
 	},
 };
 
 const mutations = {
-	authUser: (parent, { user }, { dataSources,uid, permissions}, info) => {
-		if (permissions.find((permission) => permission == 'users.Auth')) {
-			return dataSources.UserAPI.authUser(user,uid);
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}		
+	authUser: (parent, { user }, { dataSources,uid, permissions, error}, info) => {
+		return resolverHelper(error,'users.Auth',permissions) 
+			?  dataSources.UserAPI.authUser(user,uid)
+			: ERRORS.PERMISSION_DENIED				
 	},
-	updateUser: (parent, args, { dataSources,uid, permissions}, info) => {
-		if (permissions.find((permission) => permission == 'users.Update')) {
-			return dataSources.UserAPI.updateUser(args,uid);
-		} else {
-			return ERRORS.PERMISSION_DENIED;
-		}			
+	updateUser: (parent, args, { dataSources,uid, permissions, error}, info) => {
+		return resolverHelper(error,'users.Update',permissions) 
+			?  dataSources.UserAPI.updateUser(args,uid)
+			: ERRORS.PERMISSION_DENIED					
 	},
 	deleteUser: (parent, args, { dataSources,uid, permissions}, info) => {
 		return dataSources.UserAPI.deleteUser(uid);

--- a/sources/server.js
+++ b/sources/server.js
@@ -46,10 +46,14 @@ const server = new ApolloServer({
 				}
 				
 		    } catch (error) {
-		        throw new ApolloError(error.errorInfo.message,"UNAUTHORIZED");
+		        return {
+					error:{message: error.errorInfo.message,code: "UNAUTHORIZED"}
+				};
 		    }
 		}else{
-			throw new ApolloError("JWT not set","UNAUTHENTICATED");
+			return	{
+				error:{message: "JWT not set",code: "UNAUTHENTICATED"}
+			};
 		}
 	},
 	formatError: (err) => new ApolloError(err.message,err.extensions.code)


### PR DESCRIPTION
This PR includes

- revamping error handling logic at the resolver level instead of throwing it from context level
- this way the error response is preserved and context is just used for top level decoding

### previous graphql error format

```
{
	"error":{
		"errors":[
			"message":""
		]
	}
}
```

### present format

```
{
	"errors":[
		"message":""
	]	
}
```