### PR TITLE
Improve Performance

### DIFF
--- a/sources/helpers/permissions.js
+++ b/sources/helpers/permissions.js
@@ -27,8 +27,11 @@ const rolesPermissionsMap={
  * 
  * @param {String} id Mongo User id
  */
-const populatePermissions = async id => {    
+const populatePermissions = async id => {
+    console.time("permission")
     const userAccessLevels = await AccessLevels.find({ user: id })
+    
+    console.timeEnd("permission")
     if(userAccessLevels===null){
         throw new Error("User not found, Possibly outdated JWT")
     }else{        

--- a/sources/helpers/permissions.js
+++ b/sources/helpers/permissions.js
@@ -29,7 +29,7 @@ const rolesPermissionsMap={
  */
 const populatePermissions = async id => {
     console.time("permission")
-    const userAccessLevels = await AccessLevels.find({ user: id })
+    const userAccessLevels = await AccessLevels.find({ user: id }).select({club:1,level:1}).lean()
     
     console.timeEnd("permission")
     if(userAccessLevels===null){

--- a/sources/package.json
+++ b/sources/package.json
@@ -28,7 +28,8 @@
 		"firebase-admin": "^9.4.2",
 		"graphql": "^15.4.0",
 		"graphql-iso-date": "^3.6.1",
-		"mongoose": "^5.11.10"
+		"mongoose": "^5.11.10",
+		"node-cache": "^5.1.2"
 	},
 	"devDependencies": {
 		"apollo-server-testing": "^2.19.2",


### PR DESCRIPTION
### This PR includes

- Use node-cache to cache the decoded JWT which doesn't make firebase calls until the JWT expires whose TTL is set to 36000 which is the TTL of a Firebase JWT token
- Make callbacks asynchronously to reduce wait time on the server side.